### PR TITLE
Make it generate correct code on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = function (content) {
   content = doc.toString(SVGDoc.OUTPUT_FORMAT.SYMBOL);
 
   return [
-    config.angularBaseWorkaround ? 'require("' + path.resolve(__dirname, 'lib/web/angular-base-workaround') + '");' : '',
+    config.angularBaseWorkaround ? 'require("' + path.resolve(__dirname, 'lib/web/angular-base-workaround').replace(/\\/g, "/") + '");' : '',
     'var sprite = require("' + config.spriteModule.replace(/\\/g, "/") + '");',
     'var image = ' + JSON.stringify(content),
     'module.exports = sprite.add(image, "' + id + '");'


### PR DESCRIPTION
Before the fix it generated a code like ```require("c:\Work\foo\bar");``` the code is not valid, because of un-escaped slashes. I added the replace from the next array element. This resolved the issue for windows