### PR TITLE
Remove useless '#' character in react example

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ class Icon extends React.Component {
   render() {
     var glyph = this.props.glyph;
     return (
-      <svg className="icon" dangerouslySetInnerHTML={{__html: '<use xlink:href="#' + glyph + '"></use>'}}/>
+      <svg className="icon" dangerouslySetInnerHTML={{__html: '<use xlink:href="' + glyph + '"></use>'}}/>
     )
   }
 }


### PR DESCRIPTION
Remove useless '#' character in react example, the '#' character is unnecessary, because the GLYPH variable returned by this loader already have '#' character.