### PR TITLE
save preserveAspectRatio attr from original svg to symbol in sprite

### DIFF
--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ module.exports = function (content) {
 
   doc.$svg.attr('id', id);
 
-  content = doc.toString(SVGDoc.OUTPUT_FORMAT.SYMBOL);
+  content = doc.toString(SVGDoc.OUTPUT_FORMAT.SYMBOL, query.removeAttrs || null);
 
   return [
     config.angularBaseWorkaround ? 'require("' + path.resolve(__dirname, 'lib/web/angular-base-workaround').replace(/\\/g, "/") + '");' : '',

--- a/lib/svg-document.js
+++ b/lib/svg-document.js
@@ -21,7 +21,7 @@ SVGDocument.OUTPUT_FORMAT = {
  * @param {String} format
  * @returns {*}
  */
-SVGDocument.prototype.toString = function (format) {
+SVGDocument.prototype.toString = function (format, removeAttrs) {
   var result;
   var $svg = this.$svg;
   var OUTPUT_FORMAT = SVGDocument.OUTPUT_FORMAT;
@@ -40,6 +40,20 @@ SVGDocument.prototype.toString = function (format) {
       break;
 
     case OUTPUT_FORMAT.SYMBOL:
+	  
+	  //removeAttrs
+	  if(removeAttrs instanceof Array) {
+		  removeAttrs.forEach(function(element) {
+			  if(!element.selector || !element.attr)
+				  return;
+			  try {
+				$(element.selector).removeAttr(element.attr); 
+			  } catch(ex) {
+				  console.log(ex);
+			  }
+		  }.bind(this))
+	  }
+	  
       var symbolAttrs = [];
 
       // preserve following attributes

--- a/lib/svg-document.js
+++ b/lib/svg-document.js
@@ -43,7 +43,7 @@ SVGDocument.prototype.toString = function (format) {
       var symbolAttrs = [];
 
       // preserve following attributes
-      ['viewBox', 'id', 'class'].forEach(function (attr) {
+      ['viewBox', 'id', 'class', 'preserveAspectRatio'].forEach(function (attr) {
         var attrValue = $svg.attr(attr);
         attrValue && symbolAttrs.push(attr + '="' + attrValue +'"');
       });


### PR DESCRIPTION
It is useful to copy 'preserveAspectRatio' attribute from original svg icon to symbol in svg sprite (as well as id, class, viewbox) as it influences the way symbol is aligned when <svg> element that uses it is scaled (and it's ratio is different from the sybmol's ratio).