### PR TITLE
save preserveAspectRatio attr from original svg to symbol in sprite

### DIFF
--- a/lib/svg-document.js
+++ b/lib/svg-document.js
@@ -43,7 +43,7 @@ SVGDocument.prototype.toString = function (format) {
       var symbolAttrs = [];
 
       // preserve following attributes
-      ['viewBox', 'id', 'class'].forEach(function (attr) {
+      ['viewBox', 'id', 'class', 'preserveAspectRatio'].forEach(function (attr) {
         var attrValue = $svg.attr(attr);
         attrValue && symbolAttrs.push(attr + '="' + attrValue +'"');
       });


### PR DESCRIPTION
It is useful to copy 'preserveAspectRatio' attribute from original svg icon to symbol in svg sprite (as well as id, class, viewbox) as it influences the way symbol is aligned when element that uses it is scaled (and it's ratio is different from the sybmol's ratio).