### PR TITLE
Store ExtractTextPlugin instance locally

### DIFF
--- a/lib/extract-svg-plugin.js
+++ b/lib/extract-svg-plugin.js
@@ -8,17 +8,21 @@ function ExtractSVGPlugin(id, filename, options) {
   this.id = id;
   this.filename = filename;
   this.options = options;
+  this.initExtractPlugin();
 }
 
 ExtractSVGPlugin.extract = ExtractPlugin.extract;
 
-ExtractSVGPlugin.prototype.extract = ExtractPlugin.prototype.extract;
+ExtractSVGPlugin.prototype.initExtractPlugin = function () {
+  if (!this.extractPlugin) {
+    this.extractPlugin = new ExtractPlugin(this.id, this.filename, this.options);
+    this.extract = this.extractPlugin.extract.bind(this.extractPlugin);
+  }
+  return this.extractPlugin;
+}
 
 ExtractSVGPlugin.prototype.apply = function (compiler) {
-  var id = this.id;
-  var filename = this.filename;
-  var options = this.options;
-  var extractPlugin = new ExtractPlugin(id, filename, options);
+  var extractPlugin = this.initExtractPlugin();
 
   compiler.apply(extractPlugin);
 


### PR DESCRIPTION
So ExtractSVG can be used when there are more ExtractTextPlugin instances on the config.
Fixes #41