### PR TITLE
Import node into current document to prevent WrongDocumentError in IE

### DIFF
--- a/lib/web/sprite.js
+++ b/lib/web/sprite.js
@@ -192,6 +192,11 @@ Sprite.prototype.wrapSVG = function (content, template) {
   var svgString = template.replace(contentPlaceHolder, content);
 
   var svg = new DOMParser().parseFromString(svgString, 'image/svg+xml').documentElement;
+  // Fix for browser (IE, maybe other too) which are throwing 'WrongDocumentError'
+  // if you insert an element which is not part of the document
+  if (document.importNode) {
+      svg = document.importNode(svg, true);
+  }
 
   if (this.browser.name !== 'ie' && this.urlPrefix) {
     baseUrlWorkAround(svg, DEFAULT_URI_PREFIX, this.urlPrefix);


### PR DESCRIPTION
I stumbled upon this error in Edge and IE 11. I found a solution for it in the following pull request https://github.com/iconic/SVGInjector/pull/46/commits/860a89dd3c7b40ce9b20d3cb390f57e93d273baa. More infos about the fix can be found in the following stackoverflow thread http://stackoverflow.com/questions/7981100/how-do-i-dynamically-insert-an-svg-image-into-html#7986519