### PR TITLE
Fix raster image sizing

### DIFF
--- a/lib/processings/raster-image-to-svg.js
+++ b/lib/processings/raster-image-to-svg.js
@@ -5,7 +5,7 @@ var extend = require('extend');
 var objToAttrString = require('../utils').objectToAttrString;
 
 var template = [
-  '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink= "http://www.w3.org/1999/xlink" width="{width}" height="{height}">',
+  '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink= "http://www.w3.org/1999/xlink" viewBox="0 0 {width} {height}">',
     '<image width="{width}" height="{height}" xlink:href="{src}" />',
   '</svg>'
 ].join('');


### PR DESCRIPTION
* width and height are ignored by the `<symbol …` output
* they don't actually change the size of the embedded image

Putting a viewBox instead ensures that the image gets resized together with the generated symbol.