### PR TITLE
functional expansion: add regExp for ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,22 @@ module.exports = {
   }
 };
 ```
+or
+```js
+module.exports = {
+  module: {
+    loaders: [{
+      test: /\.svg$/,
+      loader: 'svg-sprite?' + JSON.stringify({
+        name: 'icon-[1]',
+        prefixize: true,
+        regExp: './my-folder/(.*)\\.svg'
+      })
+    }]
+  }
+};
+// path-to-project/my-foleder/name.svg > #icon-name
+```
 
 ## Configuration
 

--- a/config.js
+++ b/config.js
@@ -17,5 +17,6 @@ module.exports = {
   prefixize: true,
   spriteModule: path.resolve(__dirname, 'lib/web/global-sprite'),
   extract: false,
-  esModule: false
+  esModule: false,
+  regExp: null
 };

--- a/index.js
+++ b/index.js
@@ -32,7 +32,8 @@ module.exports = function (content) {
   // Calculate sprite symbol id
   var id = loaderUtils.interpolateName(this, config.name, {
     context: this.options.context,
-    content: content
+    content: content,
+    regExp: config.regExp
   });
   if (config.name.indexOf('[pathhash]') !== -1)
     id = utils.generateHashFromPath(resourcePath);


### PR DESCRIPTION
Hey man, I added feature to generate name by regex from absolute file path.

see: https://github.com/webpack/loader-utils#interpolatename
```// loaderContext.resourcePath = "/app/js/page-home.js"
loaderUtils.interpolateName(loaderContext, "script-[1].[ext]", { regExp: "page-(.*)\.js", content: ... });
// => script-home.js

```
```
