### PR TITLE
Prefix CSS selectors in embedded <style> tags (fixes #69)

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,6 +40,8 @@ module.exports = function (content) {
   if (config.prefixize)
     procs.prefixize(doc, id + '_');
 
+  procs.prefixCssSelectors(doc, '#' + id);
+
   // Check raster image pixel ratio from file name (e.g. image@2x.png)
   if (isRasterImage) {
     var pixelRatio = utils.getPixelRatioFromFilename(basename);

--- a/lib/processings/index.js
+++ b/lib/processings/index.js
@@ -1,4 +1,5 @@
 module.exports = {
   prefixize: require('./prefixize'),
-  rasterImageToSVG: require('./raster-image-to-svg')
+  rasterImageToSVG: require('./raster-image-to-svg'),
+  prefixCssSelectors: require('./prefix-css-selectors')
 };

--- a/lib/processings/prefix-css-selectors.js
+++ b/lib/processings/prefix-css-selectors.js
@@ -1,0 +1,23 @@
+var postcss = require('postcss');
+
+var prefixSelectorPlugin = postcss.plugin('postcss-prefix-selectors', function (prefix) {
+  return function (css, result) {
+    css.walkRules(function (rule) {
+      rule.selector = prefix + ' ' + rule.selector;
+    });
+  };
+});
+
+module.exports = function (doc, prefix) {
+  var $ = doc.$;
+
+  $('style').each(function () {
+    var $elem = $(this);
+    var content = $elem.text();
+
+    content = postcss([prefixSelectorPlugin(prefix)]).process(content).css;
+
+    $elem.text(content);
+  });
+}
+

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "extend": "^3.0.0",
     "image-size": "^0.3.5",
     "loader-utils": "^0.2.11",
+    "postcss": "^5.2.10",
     "sniffr": "1.1.4"
   }
 }


### PR DESCRIPTION
This uses PostCSS to rewrite CSS selectors inside SVG documents so that they are prefixed with the unique ID of each embedded document, ensuring that styling rules are isolated and don't overwrite each other when the same selectors are used in multiple documents. This fixes #69.

I've confirmed this works in my current project where I was encountering this issue.