### PR TITLE
Added stripping of backslashes after retrieving svg attribute string

### DIFF
--- a/lib/web/sprite.js
+++ b/lib/web/sprite.js
@@ -70,7 +70,7 @@ function baseUrlWorkAround(svg, currentUrlPrefix, newUrlPrefix) {
       var attributeName = attribute.localName.toLowerCase();
 
       if (fixAttributes.indexOf(attributeName) !== -1) {
-        var match = URI_FUNC_REGEX.exec(node.getAttribute(attributeName)).replace(/\\(.)/mg, "$1");
+        var match = URI_FUNC_REGEX.exec(node.getAttribute(attributeName).replace(/\\\(/g, "(").replace(/\\\)/g, ")"));
 
         // Do not touch urls with unexpected prefix
         if (match && match[1].indexOf(currentUrlPrefix) === 0) {

--- a/lib/web/sprite.js
+++ b/lib/web/sprite.js
@@ -70,7 +70,7 @@ function baseUrlWorkAround(svg, currentUrlPrefix, newUrlPrefix) {
       var attributeName = attribute.localName.toLowerCase();
 
       if (fixAttributes.indexOf(attributeName) !== -1) {
-        var match = URI_FUNC_REGEX.exec(node.getAttribute(attributeName));
+        var match = URI_FUNC_REGEX.exec(node.getAttribute(attributeName)).replace(/\\(.)/mg, "$1");
 
         // Do not touch urls with unexpected prefix
         if (match && match[1].indexOf(currentUrlPrefix) === 0) {


### PR DESCRIPTION
Currently, SVGs will stop displaying correctly if the user navigates to a URL containing parentheses and then navigates back to the portion of the URL before the parentheses. For example, when navigating from `/inbox/33(popup:compose)` to `/inbox/33`. While parentheses in URLs may be uncommon in other frameworks, they are a built-in part of Angular2's router, and so, are quite common in Angular2 applications.

The culprit seems to be https://github.com/kisenka/svg-sprite-loader/blob/master/lib/web/sprite.js#L76 where `baseUrlWorkaround` attempts to update nodes only if their properties correspond to the current URL.

The problem is that `getAttribute` returns an escaped string, so that `currentUrlPrefix` will equal something like `/inbox/33(popup:compose)` while `match[1]` equals something like `/inbox/33\(popup:compose\)`

So this removes backslashes from the string returned by `node.getAttribute` while maintaining desired ones (for example `You\\\\'re here` will still translate to `You\'re here`).