### PR TITLE
Resolve svg sprite path

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -2,7 +2,7 @@
 const Promise = require('bluebird');
 const Chunk = require('webpack/lib/Chunk');
 const SVGCompiler = require('svg-baker');
-const Sprite = require('svg-baker/lib/Sprite'); // eslint-disable-line import/no-unresolved
+const Sprite = require('svg-baker/lib/sprite');
 const { NAMESPACE } = require('./config');
 const utils = require('./utils');
 


### PR DESCRIPTION
Thanks for the awesome package, Really love the the work you're doing

This is just a PR fixing the sprite path import in plugin.js
Unix systems lint different cases within a import path fine
but when we ran on a Linux based system (travis), the linter failed due to the path error