### PR TITLE
Erroneous conditional in getLoaderOptions for multiRule

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -225,7 +225,7 @@ function getLoaderOptions(loaderPath, rule) {
   let options;
 
   if (multiRule) {
-    options = multiRule.map(normalizeRule).find(r => r.loader === loaderPath).options;
+    options = multiRule.map(normalizeRule).find(r => loaderPath.includes(r.loader)).options;
   } else {
     options = normalizeRule(rule).options;
   }


### PR DESCRIPTION
When a multiRule is used in the webpack config , in this case:
```javascript
{
  test: /\.svg$/,
  use: [
    {
      loader: 'svg-sprite-loader',
      options: {
        symbolId: '[name].[hash]',
        extract: true
      }
    },
    'svgo-loader',
  ],
},
```

an error is raised: `TypeError: Cannot read property 'options' of undefined`, originating at `svg-sprite-loader\lib\utils.js:228`.

I've managed to identify the root-cause of the issue being that the conditional used in the `map` function is `r.loader === loaderPath`, which will never be true, as `r.loader` simply is the name of the loader (in this case `svg-sprite-loader`), while `loaderPath` is an entire system path. Hence, I'm now submitting a quick-fix, which simply checks for `r.loader` to be path of the loaderPath. A more reliable solution would be preferable.

**Details**
OS: Windows 10
Node: 7.2.1
NPM: 3.10.10
svg-sprite-loader: 2.0.4