### PR TITLE
use `browser-sprite``browser-symbol` for `electron-renderer` target

### DIFF
--- a/lib/configurator.js
+++ b/lib/configurator.js
@@ -7,6 +7,8 @@ const extractTextPluginCompilerName = 'extract-text-webpack-plugin';
 const isomorphicSpriteModule = 'svg-sprite-loader/runtime/sprite.build';
 const isomorphicSymbolModule = 'svg-baker-runtime/symbol';
 
+const isTargetBrowser = target => target === 'web' || target === 'electron-renderer';
+
 /**
  * @param {Object} params
  * @param {Object} [params.config] Parsed loader config {@see SVGSpriteLoaderConfig}
@@ -19,8 +21,8 @@ module.exports = function configurator({ config, context }) {
   const compiler = context._compiler;
 
   const autoConfigured = {
-    spriteModule: target === 'web' ? defaults.spriteModule : isomorphicSpriteModule,
-    symbolModule: target === 'web' ? defaults.symbolModule : isomorphicSymbolModule,
+    spriteModule: isTargetBrowser(target) ? defaults.spriteModule : isomorphicSpriteModule,
+    symbolModule: isTargetBrowser(target) ? defaults.symbolModule : isomorphicSymbolModule,
     extract: utils.isModuleShouldBeExtracted(module),
     esModule: context.version && context.version >= 2
   };


### PR DESCRIPTION
target `electron-renderer` should be treated as `web`.