### PR TITLE
Handle the case when test is a function

### DIFF
--- a/lib/utils/get-matched-rules.js
+++ b/lib/utils/get-matched-rules.js
@@ -7,7 +7,11 @@ const ruleMatcher = require('webpack/lib/ModuleFilenameHelpers').matchObject;
  * @return {Rule[]}
  */
 function getMatchedRules(request, rules) {
-  return rules.filter(rule => ruleMatcher(rule, request));
+  return rules.filter(rule => {
+    return typeof rule.test === 'function'
+      ? rule.test(request)
+      : ruleMatcher(rule, request)
+  });
 }
 
 module.exports = getMatchedRules;

--- a/lib/utils/get-matched-rules.js
+++ b/lib/utils/get-matched-rules.js
@@ -7,10 +7,10 @@ const ruleMatcher = require('webpack/lib/ModuleFilenameHelpers').matchObject;
  * @return {Rule[]}
  */
 function getMatchedRules(request, rules) {
-  return rules.filter(rule => {
+  return rules.filter((rule) => {
     return typeof rule.test === 'function'
       ? rule.test(request)
-      : ruleMatcher(rule, request)
+      : ruleMatcher(rule, request);
   });
 }
 


### PR DESCRIPTION



**What kind of change does this PR introduce? (bugfix, feature, docs update, improvement)**

bugfix

**What is the current behavior? (You can also link to an open issue here)**

When some rule using a function instead of regex the loader fails cause `matchObject` helper expecting test to be a string or regex.

**What is the new behavior (if this is a feature change)?**

It checks whether test is a function and calling it rather than passing it to `matchObject` helper.

**Does this PR introduce a breaking change?**

nope

**Please check if the PR fulfills [contributing guidelines](../CONTRIBUTING.md#develop)**
