### PR TITLE
Support issuer filtering when matching rules (fixes #149)

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -53,7 +53,8 @@ module.exports = function loader(content) {
     throw new Exceptions.InvalidRuntimeException(config.runtimeGenerator);
   }
 
-  const matchedRules = utils.getMatchedRules(resource, utils.getLoadersRules(compiler));
+  const issuer = loaderContext._module && loaderContext._module.issuer;
+  const matchedRules = utils.getMatchedRules(resource, utils.getLoadersRules(compiler), issuer);
   if (matchedRules.length > 1 && !compiler.isChild()) {
     this.emitWarning(new Exceptions.SeveralRulesAppliedException(resource, matchedRules));
   }

--- a/lib/utils/get-matched-rules.js
+++ b/lib/utils/get-matched-rules.js
@@ -1,13 +1,29 @@
-// eslint-disable-next-line import/no-extraneous-dependencies
+/* eslint-disable import/no-extraneous-dependencies */
 const ruleMatcher = require('webpack/lib/ModuleFilenameHelpers').matchObject;
+const isWebpack1 = require('./is-webpack-1');
+const RuleSet = !isWebpack1 ? require('webpack/lib/RuleSet') : null;
 
 /**
  * @param {string} request
  * @param {Rule[]} rules Webpack loaders config
  * @return {Rule[]}
  */
-function getMatchedRules(request, rules) {
-  return rules.filter(rule => ruleMatcher(rule, request));
+function getMatchedRules(request, rules, issuer) {
+  const matchedRules = rules.filter(rule => ruleMatcher(rule, request));
+
+  if (issuer) {
+    return matchedRules.filter((rule) => {
+      // If rule doesn't have an issuer or RuleSet is not available
+      if (!rule.issuer || !RuleSet) {
+        return true;
+      }
+
+      const matcher = RuleSet.normalizeCondition(rule.issuer);
+      return matcher(issuer);
+    });
+  }
+
+  return matchedRules;
 }
 
 module.exports = getMatchedRules;

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -37,7 +37,7 @@ describe('loader and plugin', () => {
         errors[0].error.should.be.instanceOf(Exceptions.InvalidRuntimeException);
       });
 
-      it('should warn if several rules applied to module', async () => {
+      it('should warn if several rules applied to module without issuer applied', async () => {
         const { warnings } = await compile({
           entry: './entry',
           module: rules(
@@ -63,6 +63,21 @@ describe('loader and plugin', () => {
       });
 
       assets['main.js'].source().should.contain('olala');
+    });
+
+    it('should filter rules against issuer', async () => {
+      const { warnings } = await compile({
+        entry: './entry',
+        module: rules(
+          svgRule(),
+          rule({ test: /\.svg$/, loader: loaderPath, issuer: /\.css$/ })
+        )
+      });
+
+      warnings.should.be.lengthOf(isWebpack1 ? 2 : 0);
+      if (isWebpack1) {
+        warnings[0].warning.should.be.instanceOf(Exceptions.SeveralRulesAppliedException);
+      }
     });
   });
 


### PR DESCRIPTION
**What kind of change does this PR introduce? (bugfix, feature, docs update, improvement)**
This fixes an issue, most relevant since Webpack v2, where the following exception occurs because of configuration that handles .svg through multiple loaders:

`Exception: 2 rules applies to svg`

**What is the current behavior? (You can also link to an open issue here)**
Before this PR, the loader will match all rules that test against the resource only. In this case `.svg`

**What is the new behavior (if this is a feature change)?**
This PR honors the `issuer` attribute for loader configuration. If there is an issuer on the loader context, `getMatchedRules` will be passed a third argument and all the matched rules will be filtered against this issuer. 

**Does this PR introduce a breaking change?**
No, this allows webpack v2 configuration to work properly and retains the same behavior in webpack 1.

**Please check if the PR fulfills [contributing guidelines](../CONTRIBUTING.md#develop)**
#### Test coverage:
```
Webpack v1 Coverage summary:
Statements   : 95.1% ( 330/347 )
Branches     : 87.05% ( 121/139 )
Functions    : 93.67% ( 74/79 )
Lines        : 94.91% ( 317/334 )

Webpack v2 Coverage summary:
Statements   : 95.39% ( 331/347 )
Branches     : 85.61% ( 119/139 )
Functions    : 92.41% ( 73/79 )
Lines        : 95.21% ( 318/334 )
```

I have added additional tests for use with this change. Both webpack v1 and v2 are considered.