### PR TITLE
Add support for regExp pattern in the loader-util name interpolator

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ yarn add svg-sprite-loader -D
 How `<symbol>` `id` attribute should be named.
 Complete list of supported patterns: [loader-utils#interpolatename docs](https://github.com/webpack/loader-utils#interpolatename).
 
+### `symbolRegExp` (default `''`)
+Passed to the symbolId interpolator to support the [N] pattern in the loader-utils name interpolator
+
 ### `esModule` (default `true`, autoconfigured)
 
 Generated export format:

--- a/lib/config.js
+++ b/lib/config.js
@@ -21,6 +21,13 @@ module.exports = {
     symbolId: '[name]',
 
     /**
+     * Regular expression passed to interpolateName.
+     * Supports the interpolateName [N] pattern inserting the N-th match.
+     * @type {string}
+     */
+    symbolRegExp: '',
+
+    /**
      * Path to Node.js module which generates client runtime.
      * @type {string}
      */

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -60,7 +60,11 @@ module.exports = function loader(content) {
   }
 
   const idPattern = config.symbolId + (resourceQuery ? `--${urlSlug(resourceQuery)}` : '');
-  const id = interpolateName(loaderContext, idPattern, { content, context: compiler.context });
+  const id = interpolateName(loaderContext, idPattern, {
+    content,
+    context: compiler.context,
+    regExp: config.symbolRegExp
+  });
 
   svgCompiler.addSymbol({ id, content, path: resourcePath + resourceQuery })
     .then((symbol) => {


### PR DESCRIPTION
**What kind of change does this PR introduce? (bugfix, feature, docs update, improvement)**
Improvement

**What is the current behavior? (You can also link to an open issue here)**
Utilizing the [N] pattern in the symbolId field does not function as designed

**What is the new behavior (if this is a feature change)?**
The [N] pattern is properly parsed and replaced with the N-th match

**Does this PR introduce a breaking change?**
no

**Please check if the PR fulfills [contributing guidelines](../CONTRIBUTING.md#develop)**
