### PR TITLE
fix(loader): #187 support rule.oneOf config

### DIFF
--- a/lib/utils/get-loader-options.js
+++ b/lib/utils/get-loader-options.js
@@ -8,7 +8,16 @@ const isWebpack1 = require('./is-webpack-1');
  * @return {Object|null}
  */
 function getLoaderOptions(loaderPath, rule) {
-  const multiRuleProp = isWebpack1 ? 'loaders' : 'use';
+  let multiRuleProp;
+
+  if (isWebpack1) {
+    multiRuleProp = 'loaders';
+  } else if (rule.oneOf) {
+    multiRuleProp = 'oneOf';
+  } else {
+    multiRuleProp = 'use';
+  }
+
   const multiRule = typeof rule === 'object' && Array.isArray(rule[multiRuleProp]) ? rule[multiRuleProp] : null;
   let options;
 

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -389,5 +389,27 @@ describe('loader and plugin', () => {
     it('should emit only built chunks', () => {
       // TODO test with webpack-recompilation-emulator
     });
+
+    if (!webpackVersion.IS_1) {
+      it('should allow to generate specify svg sprite with rule.oneOf config', async () => {
+        const { assets } = await compile({
+          entry: './styles.css',
+          module: rules(
+            {
+              test: /\.svg$/,
+              oneOf: [
+                { loader: loaderPath, options: { extract: true, spriteFilename: '[sha1:hash:base36:10].svg' } },
+                { loader: 'svgo-loader' }
+              ]
+            },
+            cssRule()
+          ),
+          plugins: [new SpritePlugin()]
+        });
+
+        Object.keys(assets).should.be.lengthOf(2);
+        assets.should.have.property('lvn29bpor3.svg');
+      });
+    }
   });
 });


### PR DESCRIPTION
**What kind of change does this PR introduce? (bugfix, feature, docs update, improvement)**
bugfix
**What is the current behavior? (You can also link to an open issue here)**
Option spriteFilename doesn't work when using webpack rule.oneOf config
**What is the new behavior (if this is a feature change)?**
Option spriteFilename should work as normal config of webpack rule
**Does this PR introduce a breaking change?**
Nope
**Please check if the PR fulfills [contributing guidelines](../CONTRIBUTING.md#develop)**
Corresponding test case is added and all of them have passed.