### PR TITLE
fix(loader): support resourceQuery in extract mode with webpack above v1

### DIFF
--- a/lib/utils/mapped-list.js
+++ b/lib/utils/mapped-list.js
@@ -84,7 +84,7 @@ class MappedList {
     const { symbols, spriteModules, allModules, rules } = this;
     const data = symbols.reduce((acc, symbol) => {
       const resource = symbol.request.file;
-      const module = spriteModules.find(m => m.resource === resource);
+      const module = spriteModules.find(m => m.resource.split('?')[0] === resource);
       const rule = getMatchedRule(resource, rules);
       const options = rule ? getLoaderOptions(spriteLoaderPath, rule) : null;
       let spriteFilename = (options && options.spriteFilename)

--- a/test/fixtures/styles4.css
+++ b/test/fixtures/styles4.css
@@ -1,0 +1,3 @@
+.img {
+  background-image: url('img/image.svg?sprite');
+}

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -389,5 +389,22 @@ describe('loader and plugin', () => {
     it('should emit only built chunks', () => {
       // TODO test with webpack-recompilation-emulator
     });
+
+    if (!webpackVersion.IS_1) {
+      it('should emit sprite svg when using resourceQuery', async () => {
+        const { assets } = await compile({
+          entry: './styles4.css',
+          module: rules(
+            Object.assign(svgRule({ extract: true }), {
+              resourceQuery: /sprite/
+            }),
+            cssRule()
+          ),
+          plugins: [new SpritePlugin()]
+        });
+
+        Object.keys(assets).should.be.lengthOf(2);
+      });
+    }
   });
 });


### PR DESCRIPTION
**What kind of change does this PR introduce? (bugfix, feature, docs update, improvement)**

bugfix

**What is the current behavior? (You can also link to an open issue here)**

In extract mode, when svg url is required with resourceQuery like "url('./xxx.svg?sprite')" above webpack1, the corresponding svg sprite cannot be emitted.

**What is the new behavior (if this is a feature change)?**

In the above case, svg sprite should emit as normal.

**Does this PR introduce a breaking change?**

Nope

