### PR TITLE
feat(loader): Extract mode can work in either extracted CSS or style tag

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -86,6 +86,13 @@ module.exports = {
     extract: false,
 
     /**
+     * Extract mode can work in either extracted CSS or style tag.
+     * @type {boolean}
+     * @autoconfigured
+     */
+    extractCSS: true,
+
+    /**
      * Filename for generated sprite. `[chunkname]` placeholder can be used.
      * @type {string}
      */

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -69,10 +69,12 @@ module.exports = function loader(content) {
     context: compiler.context,
     regExp: config.symbolRegExp
   });
+  const publicPath = compiler.options.output.publicPath;
 
   svgCompiler.addSymbol({ id, content, path: resourcePath + resourceQuery })
     .then((symbol) => {
-      const runtime = runtimeGenerator({ symbol, config, context, loaderContext });
+      let runtime = runtimeGenerator({ symbol, config, context, loaderContext });
+      runtime = config.extractCSS ? runtime : `module.exports = '${publicPath}${resourcePath}';`;
       done(null, runtime);
     }).catch(done);
 };


### PR DESCRIPTION
**What kind of change does this PR introduce? (bugfix, feature, docs update, improvement)**
    feature
**What is the current behavior? (You can also link to an open issue here)**
    When I disable css extracted option by without using the extact-text-webpack-plugin, the final generated sprite url is rendered as ```background: url("[object object]");``` instead of extracted sprite file URL with symbol id at the end. 
**What is the new behavior (if this is a feature change)?**
    The extract mode should support the case people don't want the css be extracted, e.g. can use them in style tag.
**Does this PR introduce a breaking change?**
    Nope.
**Please check if the PR fulfills [contributing guidelines](../CONTRIBUTING.md#develop)**
    Checked.