### PR TITLE
feat: add runtimeOptions.ignoreExtract config option

### DIFF
--- a/lib/runtime-generator.js
+++ b/lib/runtime-generator.js
@@ -17,10 +17,17 @@ const {
  */
 function runtimeGenerator(params) {
   const { symbol, config, context } = params;
-  const { extract, esModule, spriteModule, symbolModule, runtimeCompat } = config;
+  const {
+    extract,
+    esModule,
+    spriteModule,
+    symbolModule,
+    runtimeCompat,
+    runtimeOptions
+  } = config;
   let runtime;
 
-  if (extract) {
+  if (extract && !runtimeOptions.ignoreExtract) {
     const spritePlaceholder = generateSpritePlaceholder(symbol.request.file);
     const data = `{
       id: ${stringify(symbol.useId)},


### PR DESCRIPTION
**What kind of change does this PR introduce? (bugfix, feature, docs update, improvement)**

feature

**What is the current behavior? (You can also link to an open issue here)**

Implements #208

**What is the new behavior?**

Setting `runtimeOptions.ignoreExtract` to `true` along with `extract` will cause svg-sprite-loader to generate the extracted SVG sprite file (e.g. sprite.svg), but not use it at runtime. The SVG sprite will still be injected into the DOM at `DOMContentLoaded` by the browser runtime.

Having the extracted sprite file can be useful for specialised workflows, such as server-side rendering in non-JS backends.

**Does this PR introduce a breaking change?**

No.

**Please check if the PR fulfills [contributing guidelines](../CONTRIBUTING.md#develop)**

👍 