### PR TITLE
fix(loader): #203 support use in rule.oneOf

### DIFF
--- a/lib/utils/get-loader-options.js
+++ b/lib/utils/get-loader-options.js
@@ -22,7 +22,8 @@ function getLoaderOptions(loaderPath, rule) {
   let options;
 
   if (multiRule) {
-    options = multiRule.map(normalizeRule).find(r => loaderPath.includes(r.loader)).options;
+    const rules = [].concat(...multiRule.map(r => (r.use || r)));
+    options = rules.map(normalizeRule).find(r => loaderPath.includes(r.loader)).options;
   } else {
     options = normalizeRule(rule).options;
   }


### PR DESCRIPTION
ISSUES CLOSED: #203

**What kind of change does this PR introduce? (bugfix, feature, docs update, improvement)**
bugfix/improvement.

**What is the current behavior? (You can also link to an open issue here)**
Option `use` doesn't work when using webpack `oneOf` rule config.

**What is the new behavior (if this is a feature change)?**
Option `use` in `oneOf` rule configuration should work as expected.

**Does this PR introduce a breaking change?**
No.

**Please check if the PR fulfills [contributing guidelines](../CONTRIBUTING.md#develop)**
It seems everything is fine =)