### PR TITLE
fix(loader): wrong build target

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -34,7 +34,7 @@ module.exports = function loader(content) {
 
   if (getWebpackVersion.IS_4) {
     configObj.config = loaderContext.query;
-    configObj.target = loaderContext.rootContext;
+    configObj.target = loaderContext.target;
   } else {
     configObj.config = getOptions(loaderContext);
     configObj.target = loaderContext.options.target || loaderContext.target;


### PR DESCRIPTION
**What kind of change does this PR introduce? (bugfix, feature, docs update, improvement)**
Bugfix

**What is the current behavior? (You can also link to an open issue here)**
A wrong `rootContext` string was passed to build config as `target`, so `spriteModule` and `symbolModule` always in isomorphic mode and can not inject `DOMContentLoaded` into bundled js

**What is the new behavior (if this is a feature change)?**
Pass right target to config

**Does this PR introduce a breaking change?**
No
