### PR TITLE
fix(utils): prevent errors for modules without resources

### DIFF
--- a/lib/utils/mapped-list.js
+++ b/lib/utils/mapped-list.js
@@ -85,7 +85,10 @@ class MappedList {
     const { symbols, spriteModules, allModules, rules } = this;
     const data = symbols.reduce((acc, symbol) => {
       const resource = symbol.request.file;
-      const module = spriteModules.find(m => m.resource.split('?')[0] === resource);
+      const module = spriteModules.find(m => 'resource' in m
+        ? m.resource.split('?')[0] === resource
+        : false
+      );
       const rule = getMatchedRule(resource, rules);
       const options = rule ? getLoaderOptions(spriteLoaderPath, rule) : null;
       let spriteFilename = (options && options.spriteFilename)

--- a/lib/utils/mapped-list.js
+++ b/lib/utils/mapped-list.js
@@ -85,10 +85,9 @@ class MappedList {
     const { symbols, spriteModules, allModules, rules } = this;
     const data = symbols.reduce((acc, symbol) => {
       const resource = symbol.request.file;
-      const module = spriteModules.find(m => 'resource' in m
-        ? m.resource.split('?')[0] === resource
-        : false
-      );
+      const module = spriteModules.find((m) => {
+        return 'resource' in m ? m.resource.split('?')[0] === resource : false;
+      });
       const rule = getMatchedRule(resource, rules);
       const options = rule ? getLoaderOptions(spriteLoaderPath, rule) : null;
       let spriteFilename = (options && options.spriteFilename)


### PR DESCRIPTION
**What kind of change does this PR introduce? (bugfix, feature, docs update, improvement)**
bugfix

**What is the current behavior? (You can also link to an open issue here)**
Some modules don't have a resource option because we have errors when splitting them

**What is the new behavior (if this is a feature change)?**
The util script skip such modules

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills [contributing guidelines](../CONTRIBUTING.md#develop)**
