### PR TITLE
`oneOf` and `rules` compositions of rule support

### DIFF
--- a/lib/utils/get-matched-rule.js
+++ b/lib/utils/get-matched-rule.js
@@ -1,14 +1,21 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const RuleSet = require('webpack/lib/RuleSet');
 
+const flattenAndExtractUse = rules => rules.reduce((pre, rule) => {
+  if ('rules' in rule || 'oneOf' in rule) {
+    return pre.concat(flattenAndExtractUse(rule.rules || rule.oneOf));
+  }
+
+  return pre.concat(rule.use || []);
+}, []);
+
 module.exports = (compiler) => {
   const rawRules = compiler.options.module.rules;
   const { rules } = new RuleSet(rawRules);
-  const rule = rules
-    .reduce((pre, cur) => pre.concat(cur.use || []), [])
+  const rule = flattenAndExtractUse(rules)
     .find((item) => {
       return /svg-sprite-loader/.test(item.loader);
-    });
+    }) || {};
 
   return rule.options || {};
 };

--- a/test/loader.test.js
+++ b/test/loader.test.js
@@ -10,6 +10,8 @@ const {
   rules,
   multiRule,
   svgRule,
+  svgInsideOneOfRule,
+  svgInsideRulesRule,
   compile,
   extractPlugin,
   extractCSSRule,
@@ -350,6 +352,30 @@ describe('loader and plugin', () => {
         entry: './entry',
         module: rules(
           svgRule()
+        ),
+        plugins: [new SpritePlugin()]
+      });
+
+      Object.keys(assets).should.be.lengthOf(1);
+    });
+
+    it('should support `oneOf` composition of rule', async () => {
+      const { assets } = await compile({
+        entry: './entry',
+        module: rules(
+          svgInsideOneOfRule()
+        ),
+        plugins: [new SpritePlugin()]
+      });
+
+      Object.keys(assets).should.be.lengthOf(1);
+    });
+
+    it('should support `rules` composition of rule', async () => {
+      const { assets } = await compile({
+        entry: './entry',
+        module: rules(
+          svgInsideRulesRule()
         ),
         plugins: [new SpritePlugin()]
       });

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -58,6 +58,30 @@ function svgRule(opts) {
   });
 }
 
+function svgInsideOneOfRule(opts) {
+  const options = merge({}, opts || {});
+
+  return rule({
+    oneOf: [{
+      test: /\.svg$/,
+      loader: loaderPath,
+      options
+    }]
+  });
+}
+
+function svgInsideRulesRule(opts) {
+  const options = merge({}, opts || {});
+
+  return rule({
+    rules: [{
+      test: /\.svg$/,
+      loader: loaderPath,
+      options
+    }]
+  });
+}
+
 /**
  * @see for webpack 1 - https://github.com/webpack-contrib/extract-text-webpack-plugin/blob/webpack-1/README.md#api
  * @see for webpack 2 - https://github.com/webpack-contrib/extract-text-webpack-plugin#options
@@ -109,6 +133,8 @@ module.exports.rule = rule;
 module.exports.rules = rules;
 module.exports.multiRule = multiRule;
 module.exports.svgRule = svgRule;
+module.exports.svgInsideOneOfRule = svgInsideOneOfRule;
+module.exports.svgInsideRulesRule = svgInsideRulesRule;
 module.exports.compile = compile;
 module.exports.compileAndNotReject = compileAndNotReject;
 module.exports.createCompiler = createCompiler;


### PR DESCRIPTION
see #rule-oneof and #rule-rules

**What kind of change does this PR introduce? (bugfix, feature, docs update, improvement)**
bugfix

**What is the current behavior? (You can also link to an open issue here)**
it doesn't support `oneOf` and `rules` composition of loader (see https://webpack.js.org/configuration/module/#rule-oneof and https://webpack.js.org/configuration/module/#rule-rules)

**What is the new behavior (if this is a feature change)?**
it supports `oneOf` and `rules` compositions

**Does this PR introduce a breaking change?**
no

**Please check if the PR fulfills [contributing guidelines](https://github.com/kisenka/svg-sprite-loader/blob/master/CONTRIBUTING.md#develop)**
