### PR TITLE
Fix the  bug of publicPath

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -216,8 +216,11 @@ class SVGSpritePlugin {
 
   beforeHtmlGeneration(compilation) {
     const itemsBySprite = this.map.groupItemsBySpriteFilename();
+    const filenamePrefix = this.rules.publicPath
+            ? this.rules.publicPath.replace(/^\//, '')
+            : '';
     const sprites = Object.keys(itemsBySprite).reduce((acc, filename) => {
-      acc[filename] = compilation.assets[filename].source();
+      acc[filenamePrefix + filename] = compilation.assets[filenamePrefix + filename].source();
       return acc;
     }, {});
 


### PR DESCRIPTION
Once  the publicPath is set and is not equal to / , an error will be report with "TypeError: Cannot read property 'source' of undefined", Because the  assets map have not contain the value of publicPath.

**What kind of change does this PR introduce?** 
> bugfix

**What is the current behavior?** 
> Someone has the same issue. _https://github.com/kisenka/svg-sprite-loader/issues/311_

**What is the new behavior (if this is a feature change)?**
The param publicPath  is available now!

**Does this PR introduce a breaking change?**
No

**Please check if the PR fulfills [contributing guidelines](https://github.com/kisenka/svg-sprite-loader/blob/master/CONTRIBUTING.md#develop)**
