### PR TITLE
Use publicPath only for html plugin case

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -167,11 +167,8 @@ class SVGSpritePlugin {
           const chunk = new Chunk(chunkName);
           chunk.ids = [];
           chunk.files.push(filename);
-          const filenamePrefix = this.rules.publicPath
-            ? this.rules.publicPath.replace(/^\//, '')
-            : '';
 
-          compilation.assets[`${filenamePrefix}${filename}`] = {
+          compilation.assets[filename] = {
             source() { return content; },
             size() { return content.length; }
           };


### PR DESCRIPTION
**What kind of change does this PR introduce? (bugfix, feature, docs update, improvement)**
bugfix

**What is the current behavior? (You can also link to an open issue here)**
publicPath used as prefix for local sprite path

**What is the new behavior (if this is a feature change)?**
publicPath will not prefixed local sprite path

**Does this PR introduce a breaking change?**
yes
**Please check if the PR fulfills [contributing guidelines](https://github.com/kisenka/svg-sprite-loader/blob/master/CONTRIBUTING.md#develop)**
