### PR TITLE
Fixes source rewrite issue when building in production

### DIFF
--- a/lib/utils/replace-in-module-source.js
+++ b/lib/utils/replace-in-module-source.js
@@ -12,6 +12,8 @@ function replaceInModuleSource(module, replacements) {
     module._source = replaceSpritePlaceholder(source, replacements);
   } else if (typeof source === 'object' && typeof source._value === 'string') {
     source._value = replaceSpritePlaceholder(source._value, replacements);
+    source._valueAsBuffer = undefined
+    source._valueAsString = undefined
   }
 
   return module;


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bugfix

**What is the current behavior?**
Issue as described in #475, I wish I had found that issue before debugging it myself. 😅

**What is the new behavior?**
Paths are correctly replaced when building for production. Clearing both `_valueAsBuffer` and `_valueAsString` seems to do the trick. 

Although this might break again in the future as this (and the current) solution seem to modify private properties. A better solution might be to replace the entire `module._source` with a new `RawSource` object, though I'm not sure if I could simply create a new `RawSource` or if that needs a require from somewhere in webpack.

**Does this PR introduce a breaking change?**
No

